### PR TITLE
Refactor: simplify discount logic with HashMap lookup

### DIFF
--- a/src/DiscountService.java
+++ b/src/DiscountService.java
@@ -1,5 +1,3 @@
-// refactored with a hashmap
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,8 +14,8 @@ public class DiscountService {
     public double applySubscriptionDiscount(double subtotal, String subscription) {
         if (subscription == null) return subtotal;
 
-        String tier = subscription.toLowerCase();
-        double rate = DISCOUNT_MAP.getOrDefault(tier, 0.0);
+        String subscription_tier = subscription.toLowerCase();
+        double rate = DISCOUNT_MAP.getOrDefault(subscription_tier, 0.0);
 
         return subtotal * (1.0 - rate);
     }

--- a/src/DiscountService.java
+++ b/src/DiscountService.java
@@ -1,3 +1,5 @@
+// refactored with a hashmap
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/DiscountService.java
+++ b/src/DiscountService.java
@@ -1,17 +1,22 @@
+import java.util.HashMap;
+import java.util.Map;
+
 public class DiscountService {
+    private static final Map<String, Double> DISCOUNT_MAP = new HashMap<>();
+
+    static {
+        DISCOUNT_MAP.put("gold", 0.15);
+        DISCOUNT_MAP.put("platinum", 0.10);
+        DISCOUNT_MAP.put("silver", 0.05);
+        DISCOUNT_MAP.put("normal", 0.0);
+    }
 
     public double applySubscriptionDiscount(double subtotal, String subscription) {
-        double rate = 0.0;
-        if (subscription != null) {
-            String tier = subscription.toLowerCase();
-            if (tier.equals("gold")) {
-                rate = 0.15;
-            } else if (tier.equals("platinum")) {
-                rate = 0.10;
-            } else if (tier.equals("silver")) {
-                rate = 0.05;
-            }
-        }
+        if (subscription == null) return subtotal;
+
+        String tier = subscription.toLowerCase();
+        double rate = DISCOUNT_MAP.getOrDefault(tier, 0.0);
+
         return subtotal * (1.0 - rate);
     }
 }


### PR DESCRIPTION
## What
Refactored subscription discount logic to use a HashMap instead of chained if/else.

Updated:
- DiscountService.java → holds a HashMap<String, Double> for tier → rate mapping and applies discounts with getOrDefault.
- Order.java → calculatePrice() now delegates to DiscountService with the cleaner lookup.

## Why
- Original code hard-coded discounts with multiple if/else checks, violating OCP and duplicating logic.
- A HashMap makes the logic shorter, easier to extend (just add a new entry), and avoids brittle string comparisons.

## How
- Introduced a static HashMap with tiers (gold, platinum, silver) mapped to rates.
- Replaced the nested if/else with a single lookup: DISCOUNT_MAP.getOrDefault(tier, 0.0).
- Order price calculation unchanged for callers; only the internal implementation is simplified.