### PR TITLE
Fix CartItem.equals/hashCode and snapshot Order items at checkout

### DIFF
--- a/src/Cart.java
+++ b/src/Cart.java
@@ -1,12 +1,14 @@
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class Cart {
     private ArrayList<CartItem> items;
-    
+
     public Cart() {
         items = new ArrayList<>();
     }
-    
+
     public void addItem(CartItem item) {
         items.add(item);
     }
@@ -14,7 +16,7 @@ public class Cart {
     public void removeItem(CartItem item) {
         items.remove(item);
     }
-    
+
     public void updateQuantity(CartItem item, int quantity) {
         for (CartItem cartItem : items) {
             if (cartItem.equals(item)) {
@@ -23,7 +25,7 @@ public class Cart {
             }
         }
     }
-    
+
     public void viewCartDetails() {
         System.out.println("Cart Details:");
         for (CartItem item : items) {
@@ -31,8 +33,8 @@ public class Cart {
         }
         System.out.println("\n");
     }
-    
-    public ArrayList<CartItem> getItems() {
-        return items;
+
+    public List<CartItem> getItems() {
+        return Collections.unmodifiableList(items);
     }
 }

--- a/src/CartItem.java
+++ b/src/CartItem.java
@@ -25,11 +25,25 @@ public class CartItem {
         this.quantity = quantity;
     }
 
-    public boolean equals(CartItem item) {
-        return this.itemName.equals(item.getName());
-    }
-
     public double getTotalPrice() {
         return price * quantity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CartItem)) return false;
+        CartItem other = (CartItem) o;
+        return this.itemName != null && this.itemName.equals(other.itemName);
+    }
+
+    @Override
+    public int hashCode() {
+        return itemName == null ? 0 : itemName.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return itemName + " x" + quantity + " @ " + price;
     }
 }

--- a/src/Order.java
+++ b/src/Order.java
@@ -1,4 +1,3 @@
-import java.util.ArrayList;
 import java.util.List;
 
 public class Order {

--- a/src/Order.java
+++ b/src/Order.java
@@ -1,3 +1,5 @@
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class Order {
@@ -21,7 +23,7 @@ public class Order {
     private List<CartItem> items;
 
     public Order(Cart cart, String subscription) {
-        this.items = cart.getItems();
+        this.items = Collections.unmodifiableList(new ArrayList<>(cart.getItems()));
         this.orderPrice = calculatePrice(subscription);
     }
 

--- a/src/Order.java
+++ b/src/Order.java
@@ -1,4 +1,5 @@
 import java.util.ArrayList;
+import java.util.List;
 
 public class Order {
     private String dateCreated;
@@ -17,8 +18,8 @@ public class Order {
     private String billingAddressState;
     private String billingAddressZip;
     private String billingAddressCountry;
-    private ArrayList<CartItem> items;
     private double orderPrice;
+    private List<CartItem> items;
 
     public Order(Cart cart, String subscription) {
         this.items = cart.getItems();


### PR DESCRIPTION
## What
- Issue: https://github.com/linhtong2026/Group-Sprint-1-Bookazon/issues/5
- Fixes broken equality in CartItem and ensures Order stores a snapshot of cart items at checkout.

## Why

- CartItem.equals(CartItem) was not overriding equals(Object), breaking remove/updateQuantity.
- No hashCode() meant inconsistent behavior in collections.
- Order held a live view of cart items, so changing the cart after checkout changed past orders.

## How

- Overrode equals(Object) and hashCode() in CartItem (identity by itemName).
- Added toString() for clarity.
- Updated Order to copy cart items into an unmodifiable list, preserving immutability.
- Kept Cart.getItems() unmodifiable to prevent external mutation.