### PR TITLE
Refactor Order class to include subtotal calculation and subscription…

### DIFF
--- a/src/Order.java
+++ b/src/Order.java
@@ -10,12 +10,19 @@ public class Order {
     private Address shippingAddress;
     private Address billingAddress;
     private double orderPrice;
+    private double subtotal;
     private List<CartItem> items;
-    private DiscountCalculator discountCalculator;
+    private Subscription subscription;
 
-    public Order(Cart cart, DiscountCalculator discountCalculator, TotalPriceCalculator totalPriceCalculator) {
-        this.discountCalculator = discountCalculator;
+    public Order(Cart cart, TotalPriceCalculator totalPriceCalculator, Subscription subscription) {
+        this.subscription = subscription;
         this.items = Collections.unmodifiableList(new ArrayList<>(cart.getItems()));
+        
+        this.subtotal = 0.0;
+        for (CartItem item : this.items) {
+            this.subtotal += item.getTotalPrice();
+        }
+        
         this.orderPrice = totalPriceCalculator.calculateTotalPrice(this.items);
     }
 
@@ -51,6 +58,20 @@ public class Order {
         System.out.println("Order Status: " + orderStatus);
         System.out.println("Shipping Address: " + (shippingAddress != null ? shippingAddress.toString() : "Not set"));
         System.out.println("Billing Address: " + (billingAddress != null ? billingAddress.toString() : "Not set"));
-        System.out.println("Order Price: $" + orderPrice);
+        
+        System.out.println();
+        System.out.println("Pricing Breakdown:");
+        System.out.printf("Subtotal: $%.2f%n", subtotal);
+        
+        if (subscription != null && subscription.discountRate() > 0) {
+            double discountAmount = subtotal - orderPrice;
+            System.out.printf("Subscription: %s%n", subscription.toString());
+            System.out.printf("Discount Amount: -$%.2f%n", discountAmount);
+        } else {
+            System.out.println("Subscription: Normal (No discount)");
+            System.out.println("Discount Amount: $0.00");
+        }
+        
+        System.out.printf("Final Total: $%.2f%n", orderPrice);
     }
 }


### PR DESCRIPTION
### What
Improved the order printing functionality to display detailed discount information including subtotal, discount amount, and subscription details.

### Why
- Users couldn't see how their subscription tier affected their final price
- The original `printOrderDetails()` method only showed the final order price without any breakdown

### How
- Added `subtotal` and `subscription` fields to the `Order` class to track discount information
- Modified the constructor to accept a `Subscription` object and calculate the subtotal before discounts
- Updated `printOrderDetails()` method to display:
  - Subtotal before discount
  - Subscription type and discount percentage  
  - Actual discount amount saved
  - Final total after discount

**Example output:**
```
Pricing Breakdown:
Subtotal: $100.00
Subscription: gold subscription (15% discount)
Discount Amount: -$15.00
Final Total: $85.00
```

Deals with issue: https://github.com/linhtong2026/Group-Sprint-1-Bookazon/issues/18#issue-3465276390